### PR TITLE
feat: display payment info with side lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,32 @@
     <style>
       body {
         margin: 0;
+        display: flex;
+        font-family: sans-serif;
+        color: #fff;
       }
       canvas {
         display: block;
       }
+      .info-list {
+        width: 200px;
+        background: rgba(0, 0, 0, 0.3);
+        padding: 10px;
+        overflow-y: auto;
+      }
+      .info-item {
+        margin-bottom: 10px;
+      }
+      .globe-container {
+        flex: 1;
+        position: relative;
+      }
     </style>
   </head>
   <body>
+    <div id="left-list" class="info-list"></div>
+    <div id="globe" class="globe-container"></div>
+    <div id="right-list" class="info-list"></div>
     <script src="./main.js"></script>
   </body>
 </html>

--- a/src/files/payments.json
+++ b/src/files/payments.json
@@ -1,0 +1,45 @@
+{
+  "type": "PaymentsCollection",
+  "payments": [
+    {
+      "user": "Alice",
+      "location": "New York, USA",
+      "amount": 120,
+      "time": "2024-05-01 10:00",
+      "lat": 40.7128,
+      "lng": -74.006
+    },
+    {
+      "user": "Bob",
+      "location": "Paris, France",
+      "amount": 85,
+      "time": "2024-05-03 14:30",
+      "lat": 48.8566,
+      "lng": 2.3522
+    },
+    {
+      "user": "Chen",
+      "location": "Beijing, China",
+      "amount": 60,
+      "time": "2024-05-05 09:15",
+      "lat": 39.9042,
+      "lng": 116.4074
+    },
+    {
+      "user": "Diego",
+      "location": "Buenos Aires, Argentina",
+      "amount": 150,
+      "time": "2024-05-08 18:45",
+      "lat": -34.6037,
+      "lng": -58.3816
+    },
+    {
+      "user": "Eva",
+      "location": "Sydney, Australia",
+      "amount": 200,
+      "time": "2024-05-10 21:00",
+      "lat": -33.8688,
+      "lng": 151.2093
+    }
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,42 +1,55 @@
 import ThreeGlobe from "three-globe";
-import { WebGLRenderer, Scene } from "three";
 import {
+  WebGLRenderer,
+  Scene,
   PerspectiveCamera,
   AmbientLight,
   DirectionalLight,
   Color,
   Fog,
-  // AxesHelper,
-  // DirectionalLightHelper,
-  // CameraHelper,
   PointLight,
-  SphereGeometry,
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
-import { createGlowMesh } from "three-glow-mesh";
 import countries from "./files/globe-data-min.json";
-import travelHistory from "./files/my-flights.json";
-import airportHistory from "./files/my-airports.json";
+import payments from "./files/payments.json";
+
 var renderer, camera, scene, controls;
+const globeContainer = document.getElementById("globe");
+const leftList = document.getElementById("left-list");
+const rightList = document.getElementById("right-list");
 let mouseX = 0;
 let mouseY = 0;
-let windowHalfX = window.innerWidth / 2;
-let windowHalfY = window.innerHeight / 2;
+let windowHalfX = globeContainer.clientWidth / 2;
+let windowHalfY = globeContainer.clientHeight / 2;
 var Globe;
 
 init();
 initGlobe();
+populateLists();
 onWindowResize();
 animate();
+
+function populateLists() {
+  const html = payments.payments
+    .map(
+      (p) =>
+        `<div class="info-item"><strong>${p.user}</strong><div>${p.location}</div><div>$${p.amount}</div><div>${p.time}</div></div>`
+    )
+    .join("");
+  leftList.innerHTML = html;
+  rightList.innerHTML = html;
+}
 
 // SECTION Initializing core ThreeJS elements
 function init() {
   // Initialize renderer
   renderer = new WebGLRenderer({ antialias: true });
   renderer.setPixelRatio(window.devicePixelRatio);
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  // renderer.outputEncoding = THREE.sRGBEncoding;
-  document.body.appendChild(renderer.domElement);
+  renderer.setSize(
+    globeContainer.clientWidth,
+    globeContainer.clientHeight
+  );
+  globeContainer.appendChild(renderer.domElement);
 
   // Initialize scene, light
   scene = new Scene();
@@ -45,7 +58,7 @@ function init() {
 
   // Initialize camera, light
   camera = new PerspectiveCamera();
-  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.aspect = globeContainer.clientWidth / globeContainer.clientHeight;
   camera.updateProjectionMatrix();
 
   var dLight = new DirectionalLight(0xffffff, 0.8);
@@ -68,14 +81,6 @@ function init() {
 
   // Additional effects
   scene.fog = new Fog(0x535ef3, 400, 2000);
-
-  // Helpers
-  // const axesHelper = new AxesHelper(800);
-  // scene.add(axesHelper);
-  // var helper = new DirectionalLightHelper(dLight);
-  // scene.add(helper);
-  // var helperCamera = new CameraHelper(dLight.shadow.camera);
-  // scene.add(helperCamera);
 
   // Initialize controls
   controls = new OrbitControls(camera, renderer.domElement);
@@ -116,41 +121,18 @@ function initGlobe() {
       ) {
         return "rgba(255,255,255, 1)";
       } else return "rgba(255,255,255, 0.7)";
-    });
-
-  // NOTE Arc animations are followed after the globe enters the scene
-  setTimeout(() => {
-    Globe.arcsData(travelHistory.flights)
-      .arcColor((e) => {
-        return e.status ? "#9cff00" : "#FF4000";
-      })
-      .arcAltitude((e) => {
-        return e.arcAlt;
-      })
-      .arcStroke((e) => {
-        return e.status ? 0.5 : 0.3;
-      })
-      .arcDashLength(0.9)
-      .arcDashGap(4)
-      .arcDashAnimateTime(1000)
-      .arcsTransitionDuration(1000)
-      .arcDashInitialGap((e) => e.order * 1)
-      .labelsData(airportHistory.airports)
-      .labelColor(() => "#ffcb21")
-      .labelDotOrientation((e) => {
-        return e.text === "ALA" ? "top" : "right";
-      })
-      .labelDotRadius(0.3)
-      .labelSize((e) => e.size)
-      .labelText("city")
-      .labelResolution(6)
-      .labelAltitude(0.01)
-      .pointsData(airportHistory.airports)
-      .pointColor(() => "#ffffff")
-      .pointsMerge(true)
-      .pointAltitude(0.07)
-      .pointRadius(0.05);
-  }, 1000);
+    })
+    .labelsData(payments.payments)
+    .labelColor(() => "#ffcb21")
+    .labelText((d) => `${d.user}\n${d.location}\n$${d.amount}\n${d.time}`)
+    .labelSize(() => 1.2)
+    .labelResolution(6)
+    .labelAltitude(0.01)
+    .pointsData(payments.payments)
+    .pointColor(() => "#ffffff")
+    .pointsMerge(true)
+    .pointAltitude(0.07)
+    .pointRadius(0.05);
 
   Globe.rotateY(-Math.PI * (5 / 9));
   Globe.rotateZ(-Math.PI / 6);
@@ -169,15 +151,18 @@ function initGlobe() {
 function onMouseMove(event) {
   mouseX = event.clientX - windowHalfX;
   mouseY = event.clientY - windowHalfY;
-  // console.log("x: " + mouseX + " y: " + mouseY);
 }
 
 function onWindowResize() {
-  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.aspect =
+    globeContainer.clientWidth / globeContainer.clientHeight;
   camera.updateProjectionMatrix();
-  windowHalfX = window.innerWidth / 1.5;
-  windowHalfY = window.innerHeight / 1.5;
-  renderer.setSize(window.innerWidth, window.innerHeight);
+  windowHalfX = globeContainer.clientWidth / 2;
+  windowHalfY = globeContainer.clientHeight / 2;
+  renderer.setSize(
+    globeContainer.clientWidth,
+    globeContainer.clientHeight
+  );
 }
 
 function animate() {


### PR DESCRIPTION
## Summary
- show payment user, location, amount and time as globe point labels
- add left and right side lists mirroring globe payment data
- include sample payment dataset

## Testing
- `npm test` (fails: no test specified)
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899acb313f0832587b9cb7fd36221cf